### PR TITLE
Remove all callback events initiated from API calls

### DIFF
--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -193,7 +193,7 @@ typedef struct GC_Chat {
 
     GC_GroupPeer    *group;
     GC_Connection   *gcc;
-    GC_Moderation   moderation;
+    GC_Moderation    moderation;
 
     GC_SharedState  shared_state;
     uint8_t         shared_state_sig[SIGNATURE_SIZE];    /* Signed by founder using the chat secret key */
@@ -651,12 +651,14 @@ bool peernumber_valid(const GC_Chat *chat, int peernumber);
  */
 GC_Chat *gc_get_group(const GC_Session *c, int groupnumber);
 
-/* Deletets peernumber from group.
+/*
+ * Deletes peernumber from group. `no_callback` should be set to true if the `peer_exit` callback should not be triggered.
  *
  * Return 0 on success.
  * Return -1 on failure.
  */
-int gc_peer_delete(Messenger *m, int groupnumber, uint32_t peernumber, const uint8_t *data, uint16_t length);
+int gc_peer_delete(Messenger *m, int groupnumber, uint32_t peernumber, const uint8_t *data, uint16_t length,
+                   bool no_callback);
 
 /* Packs mod_list into data.
  * data must have room for `num_mods * SIG_PUBLIC_KEY` bytes.

--- a/toxcore/group_connection.c
+++ b/toxcore/group_connection.c
@@ -289,7 +289,7 @@ void gcc_resend_packets(Messenger *m, GC_Chat *chat, uint32_t peernumber)
         }
 
         if (mono_time_is_timeout(m->mono_time, ary_entry->time_added, GC_CONFIRMED_PEER_TIMEOUT)) {
-            gc_peer_delete(m, chat->groupnumber, peernumber, (const uint8_t *)"Peer timed out", 14);
+            gc_peer_delete(m, chat->groupnumber, peernumber, (const uint8_t *)"Peer timed out", 14, false);
             return;
         }
     }

--- a/toxcore/tox.api.h
+++ b/toxcore/tox.api.h
@@ -4101,6 +4101,8 @@ namespace group {
      * to the ban list. It will also send a packet to all group members requesting them
      * to do the same.
      *
+     * Note: This function will not trigger the `${event peer_exit}` event for the caller.
+     *
      * @param groupnumber The group number of the group the ban is intended for.
      * @param peer_id The ID of the peer who will be kicked and/or added to the ban list.
      * @param set_ban Set to true if a ban shall be set on the peer's IP address.
@@ -4198,7 +4200,8 @@ namespace group {
   }
 
   /**
-   * This event is triggered when a moderator or founder executes a moderation event.
+   * This event is triggered when a moderator or founder executes a moderation event, with the exception
+   * of the peer who initiates the event.
    */
   event moderation {
     /**

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -472,7 +472,8 @@ static void tox_group_peer_exit_handler(Messenger *m, uint32_t groupnumber, uint
     Tox *tox = (Tox *)user_data;
 
     if (tox->group_peer_exit_callback != nullptr) {
-        tox->group_peer_exit_callback(tox, groupnumber, peer_id, name, name_length, part_message, length, tox->non_const_user_data);
+        tox->group_peer_exit_callback(tox, groupnumber, peer_id, name, name_length, part_message, length,
+                                      tox->non_const_user_data);
     }
 }
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4811,6 +4811,8 @@ typedef enum TOX_ERR_GROUP_MOD_REMOVE_PEER {
  * to the ban list. It will also send a packet to all group members requesting them
  * to do the same.
  *
+ * Note: This function will not trigger the `group_peer_exit` event for the caller.
+ *
  * @param groupnumber The group number of the group the ban is intended for.
  * @param peer_id The ID of the peer who will be kicked and/or added to the ban list.
  * @param set_ban Set to true if a ban shall be set on the peer's IP address.
@@ -4910,7 +4912,8 @@ typedef void tox_group_moderation_cb(Tox *tox, uint32_t groupnumber, uint32_t so
 /**
  * Set the callback for the `group_moderation` event. Pass NULL to unset.
  *
- * This event is triggered when a moderator or founder executes a moderation event.
+ * This event is triggered when a moderator or founder executes a moderation event, with the exception
+ * of the peer who initiates the event.
  */
 void tox_callback_group_moderation(Tox *tox, tox_group_moderation_cb *callback, void *user_data);
 


### PR DESCRIPTION
This makes all group events asynchronous. It is now the client's sole responsibility
to handle these events when they initiate them.